### PR TITLE
chore: add build watch mode

### DIFF
--- a/modules/browser/README.md
+++ b/modules/browser/README.md
@@ -34,6 +34,14 @@ if (Browser.platform('windows')) {
 }
 ```
 
+## Development
+
+In case you want to develop/debug this module while integrating with other project, please follow these steps:
+
+* Run `npm link` to create a global symlink to that module
+* Run `npm run build:watch` to listen to changes and rebuild the module
+* Link to this module from your project with `npm link @wetransfer/concorde-browser`
+
 ## API
 
 Check the available documentation on [wetransfer.github.io](https://wetransfer.github.io/concorde.js/module-Browser.html).

--- a/modules/browser/package.json
+++ b/modules/browser/package.json
@@ -7,10 +7,11 @@
     "dist/*"
   ],
   "scripts": {
-    "lint": "../../node_modules/.bin/eslint --color index.js src",
-    "test": "../../node_modules/.bin/jest",
     "build": "NODE_ENV=production ../../node_modules/.bin/rollup -c",
-    "prepublish": "npm run build"
+    "build:watch": "../../node_modules/.bin/watch 'npm run build' src",
+    "lint": "../../node_modules/.bin/eslint --color index.js src",
+    "prepublishOnly": "npm run build",
+    "test": "../../node_modules/.bin/jest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "prettier": "1.9.2",
     "rollup": "0.52.3",
     "rollup-plugin-babel": "3.0.3",
-    "rollup-plugin-uglify": "2.0.1"
+    "rollup-plugin-uglify": "2.0.1",
+    "watch": "1.0.2"
   },
   "jest": {
     "setupFiles": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4180,6 +4180,13 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+watch@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/watch/-/watch-1.0.2.tgz#340a717bde765726fa0aa07d721e0147a551df0c"
+  dependencies:
+    exec-sh "^0.2.0"
+    minimist "^1.2.0"
+
 watch@~0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"


### PR DESCRIPTION
## Proposed changes

This change adds a watch mode for build process. Helpful while developing/debugging a module while it is integrated on another project.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/concorde.js/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added necessary documentation (if appropriate)
- [ ] ~Any dependent changes have been merged and published in downstream modules~
