### PR TITLE
chore(release): npm publish 📦 [ci-skip]

### DIFF
--- a/modules/browser/CHANGELOG.md
+++ b/modules/browser/CHANGELOG.md
@@ -3,9 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.1.1"></a>
+# 1.1.1 (2018-01-02)
+
+### Bug Fixes
+
+* add support for Firefox on iOS ([#17](https://github.com/WeTransfer/concorde.js/issues/17)) ([8bf7f4c](https://github.com/WeTransfer/concorde.js/commit/8bf7f4c))
+
 <a name="1.1.0"></a>
 # 1.1.0 (2017-12-19)
-
 
 ### Bug Fixes
 

--- a/modules/browser/package.json
+++ b/modules/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wetransfer/concorde-browser",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A set of tools to get some information from the browser.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
## Proposed changes

Release a new version of `@wetransfer/concorde-browser` module.