### PR TITLE
fix: Return 0 if versions cannot be compared

### DIFF
--- a/modules/browser/__tests__/version.js
+++ b/modules/browser/__tests__/version.js
@@ -13,6 +13,10 @@ describe('Browser version module', () => {
     it('should return 1 if first version is greater than second version', () => {
       expect(diffVersions([3, 5, 1], [1, 1, 0])).toBe(2);
     });
+
+    it('should return 0 if it cannot make a comparison', () => {
+      expect(diffVersions(['NaN'], ['Foo'])).toBe(0);
+    });
   });
 
   describe('versionToArray() method', () => {

--- a/modules/browser/src/search.js
+++ b/modules/browser/src/search.js
@@ -88,7 +88,7 @@ function filterConfig(input) {
   return options.shift();
 }
 
-// Converts browser version into an arrar
+// Converts browser version into an array
 function versionFromString(browser, string) {
   const search = browser.versionSearch || browser.identity;
   const index = string.indexOf(search);

--- a/modules/browser/src/version.js
+++ b/modules/browser/src/version.js
@@ -9,7 +9,7 @@
  * @since 1.0.0
  * @param {Array} versionA One of the versions to compare.
  * @param {Array} versionB The other version to compare.
- * @returns {number} Returns the difference.
+ * @returns {number} Returns the difference or 0 if it cannot make a comparison.
  * @example
  *
  * import { diffVersions } from '@wetransfer/concorde-browser';
@@ -24,9 +24,14 @@
  * // => 2
  */
 export function diffVersions(versionA, versionB) {
+  if (versionA.some(isNaN) || versionB.some(isNaN)) {
+    return 0;
+  }
+
   let result = -1;
 
   const length = versionB.length;
+
   for (let index = 0; index < length; index++) {
     result = versionA[index] - versionB[index];
     if (result !== 0) {


### PR DESCRIPTION
## Proposed changes

The diffVersion function expects an array of integers to make a valid comparison. However, as it is now you can use an array containing whatever you want, causing weird results. This happens when the Search.version cannot retrieve the version and returns 'unknown'. Unknown is converted to an array of numbers, hence `NaN`. This bugfix ensures that diffVersion returns `0` if it cannot make a comparison. 

## Types of changes

What types of changes does your code introduce to concorde.js?
_Put an `x` in the boxes that apply_

- [X] Docs (missing or updated docs)
Minor
- [X] Bugfix (non-breaking change which fixes an issue) 
Current behavior wasn't as expected.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/WeTransfer/concorde.js/blob/master/.github/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
