### PR TITLE
chore(release): npm publish 📦 [ci-skip]

### DIFF
--- a/modules/browser/CHANGELOG.md
+++ b/modules/browser/CHANGELOG.md
@@ -3,14 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-<a name="1.3.0"></a>
-# [1.3.0](https://github.com/WeTransfer/concorde.js/compare/@wetransfer/concorde-browser@1.1.0...@wetransfer/concorde-browser@1.3.0) (2018-01-12)
+<a name="1.4.0"></a>
+# [1.4.0](https://github.com/WeTransfer/concorde.js/compare/@wetransfer/concorde-browser@1.1.0...@wetransfer/concorde-browser@1.4.0) (2018-01-15)
 
 
 ### Bug Fixes
 
-* add support for Firefox on iOS ([#17](https://github.com/WeTransfer/concorde.js/issues/17)) ([8bf7f4c](https://github.com/WeTransfer/concorde.js/commit/8bf7f4c))
-* return 0 if versions cannot be compared ([#39](https://github.com/WeTransfer/concorde.js/issues/39)) ([338840f](https://github.com/WeTransfer/concorde.js/commit/338840f))
+* build packages before publishing ([#45](https://github.com/WeTransfer/concorde.js/issues/45)) ([b6154cb](https://github.com/WeTransfer/concorde.js/commit/b6154cb))
+
+
+<a name="1.3.0"></a>
+# [1.3.0](https://github.com/WeTransfer/concorde.js/compare/@wetransfer/concorde-browser@1.1.0...@wetransfer/concorde-browser@1.3.0) (2018-01-12)
 
 
 <a name="1.2.0"></a>
@@ -20,13 +23,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Bug Fixes
 
 * add support for Firefox on iOS ([#17](https://github.com/WeTransfer/concorde.js/issues/17)) ([8bf7f4c](https://github.com/WeTransfer/concorde.js/commit/8bf7f4c))
-
-
-### Features
-
-* implement cookie module ([#22](https://github.com/WeTransfer/concorde.js/issues/22)) ([af645e2](https://github.com/WeTransfer/concorde.js/commit/af645e2))
-
-
 
 
 <a name="1.1.1"></a>

--- a/modules/browser/package.json
+++ b/modules/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wetransfer/concorde-browser",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A set of tools to get some information from the browser.",
   "main": "dist/index.js",
   "files": [

--- a/modules/cookie/CHANGELOG.md
+++ b/modules/cookie/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.2.0"></a>
+# [1.2.0](https://github.com/WeTransfer/concorde.js/compare/@wetransfer/concorde-cookie@1.0.0...@wetransfer/concorde-cookie@1.2.0) (2018-01-15)
+
+
+### Bug Fixes
+
+* build packages before publishing ([#45](https://github.com/WeTransfer/concorde.js/issues/45)) ([b6154cb](https://github.com/WeTransfer/concorde.js/commit/b6154cb))
+
+
 <a name="1.1.0"></a>
 # [1.1.0](https://github.com/WeTransfer/concorde.js/compare/@wetransfer/concorde-cookie@1.0.0...@wetransfer/concorde-cookie@1.1.0) (2018-01-12)
 

--- a/modules/cookie/package.json
+++ b/modules/cookie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wetransfer/concorde-cookie",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A set of tools to deal with cookies on the browser.",
   "main": "dist/index.js",
   "files": [

--- a/modules/debounce/CHANGELOG.md
+++ b/modules/debounce/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.2.0"></a>
+# 1.2.0 (2018-01-15)
+
+
+### Bug Fixes
+
+* build packages before publishing ([#45](https://github.com/WeTransfer/concorde.js/issues/45)) ([b6154cb](https://github.com/WeTransfer/concorde.js/commit/b6154cb))
+
+
 <a name="1.1.0"></a>
 # 1.1.0 (2018-01-12)
 

--- a/modules/debounce/package.json
+++ b/modules/debounce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wetransfer/concorde-debounce",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Debounce functions for regular and async functions.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Release: 
 - @wetransfer/concorde-browser@1.4.0
 - @wetransfer/concorde-cookie@1.2.0
 - @wetransfer/concorde-debounce@1.2.0
