### PR TITLE
chore(docs): exclude node_modules from doc generation

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -2,7 +2,7 @@
   "plugins": [],
   "source": {
     "includePattern": "modules/.+\\.js$",
-    "excludePattern": "(__tests__|dist)"
+    "excludePattern": "(__tests__|dist|node_modules)"
   },
   "tags": {
     "allowUnknownTags": false,


### PR DESCRIPTION
## Proposed changes

JSDoc was including sources from some `node_modules` present in `modules` folder. 

## Types of changes

- [ ] Docs (missing or updated docs)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/concorde.js/blob/master/.github/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
