### PR TITLE
chore(release): npm publish 📦 [ci-skip]

### DIFF
--- a/modules/browser/CHANGELOG.md
+++ b/modules/browser/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.7.0"></a>
+# [1.7.0](https://github.com/WeTransfer/concorde.js/compare/@wetransfer/concorde-browser@1.1.0...@wetransfer/concorde-browser@1.7.0) (2018-08-14)
+
+
+### Bug Fixes
+
+* add support for Firefox on iOS ([#17](https://github.com/WeTransfer/concorde.js/issues/17)) ([8bf7f4c](https://github.com/WeTransfer/concorde.js/commit/8bf7f4c))
+* **browser:** Return 0 if versions cannot be compared ([#39](https://github.com/WeTransfer/concorde.js/issues/39)) ([338840f](https://github.com/WeTransfer/concorde.js/commit/338840f))
+* build packages before publishing ([#45](https://github.com/WeTransfer/concorde.js/issues/45)) ([b6154cb](https://github.com/WeTransfer/concorde.js/commit/b6154cb))
+
+
+### Features
+
+* **browser:** add isAndroid getter ([#158](https://github.com/WeTransfer/concorde.js/issues/158)) ([1f3a917](https://github.com/WeTransfer/concorde.js/commit/1f3a917))
+* expose modules under WT global namespace ([#203](https://github.com/WeTransfer/concorde.js/issues/203)) ([6433238](https://github.com/WeTransfer/concorde.js/commit/6433238))
+* implement cookie module ([#22](https://github.com/WeTransfer/concorde.js/issues/22)) ([af645e2](https://github.com/WeTransfer/concorde.js/commit/af645e2))
+* implement debounce module ([#26](https://github.com/WeTransfer/concorde.js/issues/26)) ([31c7d99](https://github.com/WeTransfer/concorde.js/commit/31c7d99))
+
+
+
+
 <a name="1.6.0"></a>
 # [1.6.0](https://github.com/WeTransfer/concorde.js/compare/@wetransfer/concorde-browser@1.1.0...@wetransfer/concorde-browser@1.6.0) (2018-06-14)
 

--- a/modules/browser/package.json
+++ b/modules/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wetransfer/concorde-browser",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A set of tools to get some information from the browser.",
   "main": "dist/index.js",
   "files": [

--- a/modules/cookie/CHANGELOG.md
+++ b/modules/cookie/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.5.0"></a>
+# [1.5.0](https://github.com/WeTransfer/concorde.js/compare/@wetransfer/concorde-cookie@1.0.0...@wetransfer/concorde-cookie@1.5.0) (2018-08-14)
+
+
+### Bug Fixes
+
+* build packages before publishing ([#45](https://github.com/WeTransfer/concorde.js/issues/45)) ([b6154cb](https://github.com/WeTransfer/concorde.js/commit/b6154cb))
+
+
+### Features
+
+* expose modules under WT global namespace ([#203](https://github.com/WeTransfer/concorde.js/issues/203)) ([6433238](https://github.com/WeTransfer/concorde.js/commit/6433238))
+* implement debounce module ([#26](https://github.com/WeTransfer/concorde.js/issues/26)) ([31c7d99](https://github.com/WeTransfer/concorde.js/commit/31c7d99))
+
+
+
+
 <a name="1.4.0"></a>
 # [1.4.0](https://github.com/WeTransfer/concorde.js/compare/@wetransfer/concorde-cookie@1.0.0...@wetransfer/concorde-cookie@1.4.0) (2018-06-14)
 

--- a/modules/cookie/package.json
+++ b/modules/cookie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wetransfer/concorde-cookie",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A set of tools to deal with cookies on the browser.",
   "main": "dist/index.js",
   "files": [

--- a/modules/debounce/CHANGELOG.md
+++ b/modules/debounce/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.5.0"></a>
+# 1.5.0 (2018-08-14)
+
+
+### Bug Fixes
+
+* build packages before publishing ([#45](https://github.com/WeTransfer/concorde.js/issues/45)) ([b6154cb](https://github.com/WeTransfer/concorde.js/commit/b6154cb))
+* **docs:** add docs for debounceAsync function ([#58](https://github.com/WeTransfer/concorde.js/issues/58)) ([04b9889](https://github.com/WeTransfer/concorde.js/commit/04b9889))
+
+
+### Features
+
+* expose modules under WT global namespace ([#203](https://github.com/WeTransfer/concorde.js/issues/203)) ([6433238](https://github.com/WeTransfer/concorde.js/commit/6433238))
+* implement debounce module ([#26](https://github.com/WeTransfer/concorde.js/issues/26)) ([31c7d99](https://github.com/WeTransfer/concorde.js/commit/31c7d99))
+
+
+
+
 <a name="1.4.0"></a>
 # 1.4.0 (2018-06-14)
 

--- a/modules/debounce/package.json
+++ b/modules/debounce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wetransfer/concorde-debounce",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Debounce functions for regular and async functions.",
   "main": "dist/index.js",
   "files": [

--- a/modules/timer/CHANGELOG.md
+++ b/modules/timer/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.2.0"></a>
+# 1.2.0 (2018-08-14)
+
+
+### Bug Fixes
+
+* **timer:** add missing dist/index.js ([#113](https://github.com/WeTransfer/concorde.js/issues/113)) ([99bc44b](https://github.com/WeTransfer/concorde.js/commit/99bc44b))
+
+
+### Features
+
+* expose modules under WT global namespace ([#203](https://github.com/WeTransfer/concorde.js/issues/203)) ([6433238](https://github.com/WeTransfer/concorde.js/commit/6433238))
+* implement timer module ([#108](https://github.com/WeTransfer/concorde.js/issues/108)) ([a06f210](https://github.com/WeTransfer/concorde.js/commit/a06f210))
+
+
+
+
 <a name="1.1.0"></a>
 # 1.1.0 (2018-06-14)
 

--- a/modules/timer/package.json
+++ b/modules/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wetransfer/concorde-timer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Useful functions to deal with timing in JavaScript.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
 - @wetransfer/concorde-browser@1.7.0
 - @wetransfer/concorde-cookie@1.5.0
 - @wetransfer/concorde-debounce@1.5.0
 - @wetransfer/concorde-timer@1.2.0
