### PR TITLE
feat: add reset method

### DIFF
--- a/modules/timer/README.md
+++ b/modules/timer/README.md
@@ -159,6 +159,25 @@ stopwatch.stop();
 // Don't expect anything to happen
 ```
 
+**timer.reset**
+
+Resets the current Timer, aka, stop, restore the remaining time and start again.
+
+```js
+// (T)
+function timedFunction() {
+  console.log('ping!');
+}
+
+const stopwatch = new Timer(10000, timedFunction);
+
+// (T+2 seconds)
+stopwatch.reset();
+
+// (T+12 seconds)
+// 'peng!'
+```
+
 ## Development
 
 In case you want to develop/debug this module while integrating with other project, please follow these steps:

--- a/modules/timer/src/timer.js
+++ b/modules/timer/src/timer.js
@@ -16,7 +16,7 @@ export default class Timer {
    *
    * // (T)
    * const timedFunction = () => {
-   *    console.log('ping!')
+   *    console.log('peng!')
    * }
    *
    * const stopwatch = new Timer(10000, timedFunction);
@@ -27,7 +27,7 @@ export default class Timer {
    * // => Timer {remaining: 5000, callback: ƒ, paused: false, delay: 10, time: 1523436647000}
    *
    * // (T+10 seconds)
-   * // 'ping!'
+   * // 'peng!'
    */
   constructor(delay = 0, callback) {
     // Callback MUST be a function

--- a/modules/timer/src/timer.js
+++ b/modules/timer/src/timer.js
@@ -130,6 +130,33 @@ export default class Timer {
   }
 
   /**
+   * Resets the current Timer
+   * @since 1.3.0
+   * @function reset
+   * @example
+   * import Timer from '@wetransfer/concorde-timer';
+   *
+   * // (T)
+   * const timedFunction = () => {
+   *    console.log('peng!');
+   * }
+   *
+   * const stopwatch = new Timer(10000, timedFunction);
+   *
+   * // (T+2 seconds)
+   * stopwatch.reset();
+   *
+   * // (T+12 seconds)
+   * // 'peng!'
+   */
+  reset() {
+    // Stop and keep track of the current time remaining
+    this.stop();
+    this.remaining = this.delay;
+    this.start();
+  }
+
+  /**
    * Resumes the current Timer
    * @since 1.0.0
    * @function resume


### PR DESCRIPTION
## Proposed changes

Add a new `reset` method that stops the actual timer, restores the value of `remainingTime` to the original delay and starts the timer again.

## Types of changes

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/concorde.js/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
