### PR TITLE
fix: target e5 only compatible browsers

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,18 +9,6 @@ const presets = {
       },
     ],
   ],
-  production: [
-    [
-      '@babel/preset-env',
-      {
-        targets: {
-          'ie': '9',
-        },
-        useBuiltIns: false,
-        modules: false,
-      },
-    ],
-  ],
 };
 
 module.exports = {

--- a/scripts/build/webpack.config.js
+++ b/scripts/build/webpack.config.js
@@ -18,6 +18,18 @@ module.exports = (moduleName) => ([
             loader: 'babel-loader',
             options: {
               cacheDirectory: true,
+              presets: [
+                [
+                  '@babel/preset-env',
+                  {
+                    targets: {
+                      browsers: ['ie >= 9'],
+                    },
+                    useBuiltIns: false,
+                    modules: false,
+                  },
+                ],
+              ],
             },
           }],
           test: /\.(js)$/,


### PR DESCRIPTION
## Proposed changes

Somewhere between `timer@1.2.0` and `timer@1.3.0` releases, and dozens of dependency updates, the final build was not ES5 compatible anymore. Moving browser list from `babel.config.js` file to Webpack configuration apparently solves the issue.

## Types of changes

- [ ] Docs (missing or updated docs)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/concorde.js/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
