### PR TITLE
feat: Add clipboard module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains a collection of modules used internally by WeTransfer t
 | [concorde-cookie](https://github.com/WeTransfer/concorde.js/tree/master/modules/cookie) | [![npm version](https://badge.fury.io/js/%40wetransfer%2Fconcorde-cookie.svg)](https://badge.fury.io/js/%40wetransfer%2Fconcorde-cookie) | Read, write and clean cookies |
 | [concorde-debounce](https://github.com/WeTransfer/concorde.js/tree/master/modules/debounce) | [![npm version](https://badge.fury.io/js/%40wetransfer%2Fconcorde-debounce.svg)](https://badge.fury.io/js/%40wetransfer%2Fconcorde-debounce) | Debounce functions for regular and async functions |
 | [concorde-timer](https://github.com/WeTransfer/concorde.js/tree/master/modules/timer) | [![npm version](https://badge.fury.io/js/%40wetransfer%2Fconcorde-timer.svg)](https://badge.fury.io/js/%40wetransfer%2Fconcorde-timer) | Useful functions to deal with timing in JavaScript |
+| [concorde-clipboard](https://github.com/WeTransfer/concorde.js/tree/master/modules/clipboard) | [![npm version](https://badge.fury.io/js/%40wetransfer%2Fconcorde-clipboard.svg)](https://badge.fury.io/js/%40wetransfer%2Fconcorde-clipboard) | Universal copy to clipboard function for the browser |
 
 ## Usage
 

--- a/modules/browser/__e2e__/index.spec.js
+++ b/modules/browser/__e2e__/index.spec.js
@@ -1,4 +1,4 @@
-describe('Browser bundle', async () => {
+describe('Browser bundle', () => {
   let page;
 
   beforeAll(async () => {

--- a/modules/clipboard/README.md
+++ b/modules/clipboard/README.md
@@ -1,0 +1,80 @@
+# concorde-clipboard
+[![npm version](https://badge.fury.io/js/%40wetransfer%2Fconcorde-clipboard.svg)](https://badge.fury.io/js/%40wetransfer%2Fconcorde-clipboard)
+
+Universal copy to clipboard function for the browser.
+
+## Installation
+
+```sh
+npm install @wetransfer/concorde-clipboard --save
+```
+
+## Usage
+
+### In the browser
+
+Import the package if your are using a package bundler like Webpack or Parcel. Please notice that some browsers only allow to access the clipboard in response to user interaction:
+
+```js
+import { copyToClipboard } from '@wetransfer/concorde-clipboard';
+
+button.addEventListener('click', async function copy() {
+  try {
+    await copyToClipboard('Your content goes here');
+    console.log('Text copied to the clipboard!');
+  } catch(error) {
+    console.error('We couldn\'t copy to the clipboard', error);
+  }
+});
+```
+
+Or load directly the final bundle on your browser, using a script tag. All concorde.js modules will be available in a global variable called `WT`:
+
+```html
+<!-- This will load the latest version of @wetransfer/concorde-clipboard module -->
+<script src="https://unpkg.com/@wetransfer/concorde-clipboard/dist/concorde-clipboard.min.js"></script>
+<script>
+  button.addEventListener('click', async function copy() {
+    try {
+      await WT.clipboard.copyToClipboard('Your content goes here');
+      console.log('Text copied to the clipboard!');
+    } catch(error) {
+      console.error('We couldn\'t copy to the clipboard', error);
+    }
+  });
+</script>
+```
+
+## Functions
+
+**isClipboardSupported**
+
+Returns `true` if [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) is supported or [Document.execCommand('copy')](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) can be used. Please be aware that even if these methods are available, we cannot guarantee that content can be copied to the clipboard.
+
+```js
+console.log('Is clipboard supported? ', isClipboardSupported());
+```
+
+**copyToClipboard**
+
+Copy the provided text to the user's clipboard. This function returns a promise that resolves if we can copy to the clipboard. We will try to use the Clipboard API first, and fallback to Document.execCommand if something goes wrong. We will reject the promise if we cannot copy the text to the clipboard.
+
+```js
+button.addEventListener('click', async function copy() {
+  try {
+    await copyToClipboard('Your content goes here');
+    console.log('Text copied to the clipboard!');
+  } catch(error) {
+    console.error('We couldn\'t copy to the clipboard', error);
+  }
+});
+```
+
+## Development
+
+In case you want to develop/debug this module while integrating with other project, please follow these steps:
+
+* Run `npm link` to create a global symlink to that module
+* Run `npm run build:watch` to listen to changes and rebuild the module
+* Link to this module from your project with `npm link @wetransfer/concorde-clipboard`
+

--- a/modules/clipboard/__tests__/clipboard.spec.js
+++ b/modules/clipboard/__tests__/clipboard.spec.js
@@ -1,0 +1,123 @@
+import { isClipboardSupported, copyToClipboard } from '../index';
+
+jest.useFakeTimers();
+
+describe('Clipboard module', () => {
+  Object.defineProperty(global.navigator, 'clipboard', {
+    writable: true,
+    value: undefined,
+  });
+
+  Object.defineProperty(global.document, 'execCommand', {
+    writable: true,
+    value: undefined,
+  });
+
+  Object.defineProperty(global.navigator, 'permissions', {
+    writable: true,
+    value: undefined,
+  });
+
+  describe('isClipboardSupported function', () => {
+    it('should return false if neither Clipboard API or document.execCommand are available', () => {
+      expect(isClipboardSupported()).toBe(false);
+    });
+
+    describe('when Clipboard API is available', () => {
+      beforeEach(() => {
+        global.navigator.clipboard = {};
+      });
+
+      it('should return true', () => {
+        expect(isClipboardSupported()).toBe(true);
+      });
+    });
+
+    describe('when document.execCommand available', () => {
+      beforeEach(() => {
+        global.document.execCommand = jest.fn();
+      });
+
+      it('should return true', () => {
+        expect(isClipboardSupported()).toBe(true);
+      });
+    });
+  });
+
+  describe('copyToClipboard function', () => {
+    let clipboardSpy;
+    let permissionsSpy;
+    let execCommandSpy;
+
+    beforeEach(() => {
+      execCommandSpy = jest.fn(() => true);
+      clipboardSpy = { writeText: jest.fn() };
+      permissionsSpy = { query: jest.fn() };
+
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36',
+      });
+
+      permissionsSpy.query.mockReturnValue(Promise.resolve({ state: 'granted' }));
+      global.navigator.clipboard = clipboardSpy;
+      global.navigator.permissions = permissionsSpy;
+      global.document.execCommand = execCommandSpy;
+      global.document.createRange = jest.fn(() => ({
+        selectNodeContents: jest.fn(),
+      }));
+      global.getSelection = jest.fn(() => ({
+        addRange: jest.fn(),
+        removeAllRanges: jest.fn(),
+      }));
+    });
+
+    it('should copy the text using Clipboard API', async () => {
+      await copyToClipboard('Text to be copied!');
+      expect(clipboardSpy.writeText).toHaveBeenCalledWith('Text to be copied!');
+    });
+
+    it('should copy the text using execCommand if no permissions for Clipboard API are available', async () => {
+      permissionsSpy.query.mockReturnValue(Promise.resolve({ state: 'denied' }));
+      await copyToClipboard('Text to be copied!');
+      expect(execCommandSpy).toHaveBeenCalledWith('copy');
+    });
+
+    it('should copy the text using execCommand if Permissions API throws an error', async () => {
+      permissionsSpy.query.mockReturnValue(Promise.reject({ state: 'denied' }));
+      await copyToClipboard('Text to be copied!');
+      expect(execCommandSpy).toHaveBeenCalledWith('copy');
+    });
+
+    it('should copy the text using execCommand if Clipboard API is not available', async () => {
+      global.navigator.clipboard = undefined;
+      await copyToClipboard('Text to be copied!');
+      expect(execCommandSpy).toHaveBeenCalledWith('copy');
+    });
+
+    it('should copy the text using execCommand if Permissions API is not available', async () => {
+      global.navigator.permissions = undefined;
+      await copyToClipboard('Text to be copied!');
+      expect(execCommandSpy).toHaveBeenCalledWith('copy');
+    });
+
+    it('should copy the text in the next event loop using execCommand on iOS devices', (done) => {
+      global.navigator.permissions = undefined;
+      Object.defineProperty(global.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_1 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A403 Safari/602.1',
+      });
+      copyToClipboard('Text to be copied!');
+      jest.runAllTimers();
+      process.nextTick(() => {
+        expect(setTimeout).toHaveBeenCalledTimes(1);
+        expect(execCommandSpy).toHaveBeenCalledWith('copy');
+        done();
+      });
+    });
+
+    it('should throw an error if execCommand did not succeded', async () => {
+      permissionsSpy.query.mockReturnValue(Promise.reject({ state: 'denied' }));
+      global.document.execCommand.mockReturnValue(false);
+      await expect(copyToClipboard('Text to be copied!')).rejects.toEqual(new DOMException());
+    });
+  });
+});

--- a/modules/clipboard/babel.config.js
+++ b/modules/clipboard/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../babel.config.js');

--- a/modules/clipboard/dist/index.js
+++ b/modules/clipboard/dist/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'development') {
+  module.exports = require('./concorde-clipboard.js');
+} else {
+  module.exports = require('./concorde-clipboard.min.js');
+}

--- a/modules/clipboard/index.js
+++ b/modules/clipboard/index.js
@@ -1,0 +1,2 @@
+module.exports.isClipboardSupported = require('./src/clipboard').isClipboardSupported;
+module.exports.copyToClipboard = require('./src/clipboard').copyToClipboard;

--- a/modules/clipboard/jest.config.js
+++ b/modules/clipboard/jest.config.js
@@ -1,0 +1,7 @@
+const config = require('../../scripts/jest/default-config');
+
+module.exports = config({
+  setupFiles: [
+    '../../scripts/jest/setup-environment.js',
+  ],
+});

--- a/modules/clipboard/package.json
+++ b/modules/clipboard/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@wetransfer/concorde-clipboard",
+  "version": "1.0.0",
+  "description": "Copy to clipboard function for the browser.",
+  "main": "dist/index.js",
+  "files": [
+    "dist/*"
+  ],
+  "scripts": {
+    "build": "../../node_modules/.bin/webpack --mode production",
+    "build:dev": "../../node_modules/.bin/webpack --mode development",
+    "build:watch": "npm run build:dev -- --watch",
+    "lint": "../../node_modules/.bin/eslint --color *.js src __tests__",
+    "lint:fix": "npm run lint -- --fix",
+    "prepublish": "npm run build && npm run build:dev",
+    "test": "../../node_modules/.bin/jest",
+    "test:watch": "../../node_modules/.bin/jest --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/WeTransfer/concorde.js.git"
+  },
+  "keywords": [
+    "clipboard",
+    "copy",
+    "async",
+    "browser",
+    "wetransfer"
+  ],
+  "author": "WeTransfer folks",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/WeTransfer/concorde.js/issues"
+  },
+  "homepage": "https://github.com/WeTransfer/concorde.js#readme",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/modules/clipboard/src/clipboard.js
+++ b/modules/clipboard/src/clipboard.js
@@ -1,0 +1,121 @@
+let shadowTextArea;
+let lazyRange;
+
+export function isClipboardSupported() {
+  return navigator.clipboard !== undefined || document.execCommand !== undefined;
+}
+
+export function copyToClipboard(text) {
+  // Fallback to document.execCommand if Clipboard API is not available
+  // or Permissions API is not available.
+  if (!navigator.clipboard || !navigator.permissions) {
+    return writeLegacy(text);
+  }
+
+  // Check if we can write into the clipboard
+  return navigator.permissions
+    .query({ name: 'clipboard-write' })
+    .then(({ state }) => ['granted', 'prompt'].includes(state))
+    .then((canWrite) => {
+      if (canWrite) {
+        return navigator.clipboard.writeText(text);
+      }
+
+      // Fallback to document.execCommand if something goes wrong.
+      return writeLegacy(text);
+    })
+    .catch(() => writeLegacy(text));
+}
+
+function writeLegacy(text) {
+  return new Promise((resolve, reject) => {
+    const activeElement = document.activeElement;
+    const textArea = getTextArea();
+
+    if (navigator.userAgent.match(/iPhone|iPad|iPod/i)) {
+      // Without this `setTimeout` the page on iOS twitches/jumps up and down
+      setTimeout(selectAndCopy, 0, { textArea, text, activeElement, resolve, reject });
+    } else {
+      selectAndCopy({ textArea, text, activeElement, resolve, reject });
+    }
+  });
+}
+
+function getTextArea() {
+  if (!shadowTextArea) {
+    shadowTextArea = document.createElement('textarea');
+    shadowTextArea.style.cssText = `
+      position: absolute;
+      left: -4444px;
+      zIndex: -1;
+      opacity: 0.01;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: 0;
+      border: 0;
+    `;
+
+    // Without readOnly attribute, iOS (may be others as well) will show
+    // a popup hint with actions like "select all", "copy" and so on.
+    // It will also show the keyboard, which is not desired.
+    shadowTextArea.readOnly = true;
+
+    // To be able to use `document.execCommand` the element
+    // must be inside the form or contentEditable.
+    // At least the documentation says so.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
+    // In fact it also works without contentEditable,
+    // but usually it is better to follow the documentation :)
+    shadowTextArea.contentEditable = 'true';
+    shadowTextArea.tabIndex = -1;
+    document.body.appendChild(shadowTextArea);
+  }
+
+  // Position the text area in a visible part of the page,
+  // so the page does not quickly "jump" to the position of the text area
+  // and then back to it's previous position.
+  // This is needed because the text area needs to be focused
+  // when document.execCommand is being executed.
+  shadowTextArea.style.top = `${document.body.scrollTop}px`;
+
+  return shadowTextArea;
+}
+
+function getRange() {
+  if (!lazyRange) {
+    lazyRange = document.createRange();
+  }
+
+  return lazyRange;
+}
+
+function selectAndCopy({
+  textArea,
+  text,
+  activeElement,
+  resolve,
+  reject,
+}) {
+  const range = getRange();
+
+  textArea.focus();
+  textArea.value = text;
+  range.selectNodeContents(textArea);
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+  textArea.setSelectionRange(0, text.length);
+
+  const isCopied = document.execCommand('copy');
+
+  if (activeElement) {
+    activeElement.focus();
+  }
+
+  if (isCopied) {
+    resolve();
+  } else {
+    reject(new DOMException('The request is not allowed', 'NotAllowedError'));
+  }
+}

--- a/modules/clipboard/webpack.config.js
+++ b/modules/clipboard/webpack.config.js
@@ -1,0 +1,3 @@
+const webpackConfig = require('../../scripts/build/webpack.config');
+
+module.exports = webpackConfig('clipboard');

--- a/modules/cookie/__e2e__/index.spec.js
+++ b/modules/cookie/__e2e__/index.spec.js
@@ -1,4 +1,4 @@
-describe('Cookie bundle', async () => {
+describe('Cookie bundle', () => {
   let page;
 
   beforeAll(async () => {

--- a/modules/debounce/__e2e__/index.spec.js
+++ b/modules/debounce/__e2e__/index.spec.js
@@ -1,4 +1,4 @@
-describe('Debounce bundle', async () => {
+describe('Debounce bundle', () => {
   let page;
 
   beforeAll(async () => {

--- a/modules/timer/__e2e__/index.spec.js
+++ b/modules/timer/__e2e__/index.spec.js
@@ -1,4 +1,4 @@
-describe('Debounce bundle', async () => {
+describe('Debounce bundle', () => {
   let page;
 
   beforeAll(async () => {


### PR DESCRIPTION
## Proposed changes

Create a Clipboard module, that allows applications to set text on user's clipboards. We try to use Clipboard API first, and fallback to old style `document.execCommand` if not available.

## Types of changes

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/concorde.js/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
